### PR TITLE
feat: [SRTP-557] add GDP index fields to Rtp

### DIFF
--- a/src/main/java/it/gov/pagopa/rtp/sender/domain/rtp/Rtp.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/domain/rtp/Rtp.java
@@ -17,7 +17,8 @@ public record Rtp(String noticeNumber, BigDecimal amount, String description, Lo
                   String subject, LocalDateTime savingDateTime, String serviceProviderDebtor,
                   String iban,
                   String payTrxRef, String flgConf, RtpStatus status,
-                  String serviceProviderCreditor, List<Event> events) {
+                  String serviceProviderCreditor, List<Event> events,
+                  Long operationId, String eventDispatcher) {
 
   public Rtp toRtpWithActivationInfo(String rtpSpId) {
     return Rtp.builder()

--- a/src/main/java/it/gov/pagopa/rtp/sender/repository/rtp/RtpEntity.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/repository/rtp/RtpEntity.java
@@ -44,5 +44,7 @@ public class RtpEntity {
   private RtpStatus status;
   private String serviceProviderCreditor;
   private List<Event> events;
+  private Long operationId;
+  private String eventDispatcher;
 
 }

--- a/src/test/java/it/gov/pagopa/rtp/sender/controller/rtp/RtpDtoMapperTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/sender/controller/rtp/RtpDtoMapperTest.java
@@ -143,7 +143,9 @@ class RtpDtoMapperTest {
             "Y",
             RtpStatus.SENT,
             "CREDITOR-001",
-            List.of(event)
+            List.of(event),
+            1L,
+            "eventDispatcher"
     );
 
     RtpDto dto = rtpDtoMapper.toRtpDto(rtp);

--- a/src/test/java/it/gov/pagopa/rtp/sender/service/rtp/handler/CancelRtpResponseHandlerTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/sender/service/rtp/handler/CancelRtpResponseHandlerTest.java
@@ -141,25 +141,11 @@ class CancelRtpResponseHandlerTest {
   }
 
   private Rtp createRtpWithStatus() {
-    return new Rtp(
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        new ResourceID(UUID.randomUUID()),
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        RtpStatus.SENT,
-        null,
-        new ArrayList<>());
+    return Rtp.builder()
+        .resourceID(new ResourceID(UUID.randomUUID()))
+        .status(RtpStatus.SENT)
+        .events(new ArrayList<>())
+        .build();
   }
 
   private Rtp cancelRtpWithSameEvents(Rtp original) {


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR adds the fields `operationId` and `eventDispatcher` to `Rtp` and `RtpEntity` model classes: those fields are needed to keep track of the source of the `Rtp` upon creation, which are later needed to fetch said document in a _UPDATE_/_DELETE_ operation.

#### List of Changes
<!--- Describe your changes in detail -->
- Added `operationId` and `eventDispatcher`fields to `Rtp`;
- Added `operationId` and `eventDispatcher` fields to `RtpEntity`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This work enables the persistence of the aforementioned fields, required to determine which document to act upon whenever a _UPDATE_/_DELETE_ operation event is consumed.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [X] Unit
  - [ ] Integration (Narrow)
- Post-Deploy Test
  - [ ] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] PATCH - Bug fix (backwards compatible bug fixes)
- [X] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
