### PR TITLE
fix: [SRTP-577] set creDtTm to current time for cancellations

### DIFF
--- a/src/main/java/it/gov/pagopa/rtp/sender/service/rtp/SepaRequestToPayMapper.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/service/rtp/SepaRequestToPayMapper.java
@@ -2,6 +2,7 @@ package it.gov.pagopa.rtp.sender.service.rtp;
 
 import it.gov.pagopa.rtp.sender.utils.IdentifierUtils;
 import java.net.URI;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -320,7 +321,7 @@ public class SepaRequestToPayMapper {
         .id(IdentifierUtils.formatUuidWithoutHyphens(rtp.resourceID().getId()))
         .assgnr(party40ChoiceAssigner)
         .assgne(party40ChoiceAssignee)
-        .creDtTm(DateUtils.localDateTimeToOffsetFormat(rtp.savingDateTime()));
+        .creDtTm(DateUtils.localDateTimeToOffsetFormat(LocalDateTime.now()));
 
     final var organisationIdentification29EPC25922V30DS112Dto = new OrganisationIdentification29EPC25922V30DS112Dto() //OrgId
         .othr(new GenericOrganisationIdentification1EPC25922V30DS112Dto()

--- a/src/test/java/it/gov/pagopa/rtp/sender/service/rtp/SepaRequestToPayMapperTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/sender/service/rtp/SepaRequestToPayMapperTest.java
@@ -1,13 +1,8 @@
 package it.gov.pagopa.rtp.sender.service.rtp;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.math.BigDecimal;
 import java.time.*;
-
-import it.gov.pagopa.rtp.sender.utils.DateUtils;
+import java.time.format.DateTimeFormatter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +15,7 @@ import it.gov.pagopa.rtp.sender.domain.rtp.ResourceID;
 import it.gov.pagopa.rtp.sender.domain.rtp.Rtp;
 import it.gov.pagopa.rtp.sender.epcClient.model.ExternalCancellationReason1CodeDto;
 import it.gov.pagopa.rtp.sender.epcClient.model.ExternalOrganisationIdentification1CodeEPC25922V30DS022Dto;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
 class SepaRequestToPayMapperTest {
@@ -231,7 +227,7 @@ class SepaRequestToPayMapperTest {
     String serviceProviderCreditor = "serviceProviderCreditor";
     String serviceProviderDebtor = "serviceProviderDebtor";
     String expectedDate = "2025-01-01T12:31:20+01:00";
-    String expectedCreationDateTime = DateUtils.localDateTimeToOffsetFormat(LocalDateTime.now());
+    DateTimeFormatter creationDateTimeFormat = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 
     final var nRtp = Rtp.builder()
         .resourceID(resourceId)
@@ -299,10 +295,7 @@ class SepaRequestToPayMapperTest {
     final var caseAssignment = result.getDocument().getCstmrPmtCxlReq().getAssgnmt();
     assertEquals(resourceId.getId().toString().replace("-",""),
         caseAssignment.getId());
-    assertTrue(Duration.between(
-            OffsetDateTime.parse(expectedCreationDateTime),
-            OffsetDateTime.parse(caseAssignment.getCreDtTm())
-    ).abs().toMillis() < 1000);
+    assertDoesNotThrow(() -> creationDateTimeFormat.parse(caseAssignment.getCreDtTm()));
     assertEquals(pagoPaConfigProperties.details().fiscalCode(),
         caseAssignment.getAssgnr().getPty().getId().getOrgId().getOthr().getId());
     assertEquals(serviceProviderDebtor,

--- a/src/test/java/it/gov/pagopa/rtp/sender/service/rtp/SepaRequestToPayMapperTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/sender/service/rtp/SepaRequestToPayMapperTest.java
@@ -5,10 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.*;
 
+import it.gov.pagopa.rtp.sender.utils.DateUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -232,6 +231,7 @@ class SepaRequestToPayMapperTest {
     String serviceProviderCreditor = "serviceProviderCreditor";
     String serviceProviderDebtor = "serviceProviderDebtor";
     String expectedDate = "2025-01-01T12:31:20+01:00";
+    String expectedCreationDateTime = DateUtils.localDateTimeToOffsetFormat(LocalDateTime.now());
 
     final var nRtp = Rtp.builder()
         .resourceID(resourceId)
@@ -299,8 +299,10 @@ class SepaRequestToPayMapperTest {
     final var caseAssignment = result.getDocument().getCstmrPmtCxlReq().getAssgnmt();
     assertEquals(resourceId.getId().toString().replace("-",""),
         caseAssignment.getId());
-    assertEquals(expectedDate,
-        caseAssignment.getCreDtTm());
+    assertTrue(Duration.between(
+            OffsetDateTime.parse(expectedCreationDateTime),
+            OffsetDateTime.parse(caseAssignment.getCreDtTm())
+    ).abs().toMillis() < 1000);
     assertEquals(pagoPaConfigProperties.details().fiscalCode(),
         caseAssignment.getAssgnr().getPty().getId().getOrgId().getOthr().getId());
     assertEquals(serviceProviderDebtor,


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR updates the logic used to populate the creDtTm field in cancellation messages. Instead of using the RTP creation date, the field is now correctly set to the actual time the cancellation is sent.

#### List of Changes
<!--- Describe your changes in detail -->
- Updated creDtTm assignment in SepaRequestToPayMapper to use the current time

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The previous behavior caused the cancellation to carry an incorrect timestamp, potentially leading to misunderstandings in message tracking. This change ensures consistency with expected behavior.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [x] Unit
  - [x] Integration (Narrow)
- Post-Deploy Test
  - [x] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
