### PR TITLE
feat: [SRTP-632] implement update paid RTP with same PSP tax code

### DIFF
--- a/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/business/OperationProcessorFactory.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/business/OperationProcessorFactory.java
@@ -6,7 +6,7 @@ import it.gov.pagopa.rtp.sender.domain.gdp.GdpMessage;
 import it.gov.pagopa.rtp.sender.domain.gdp.GdpMessage.Operation;
 import it.gov.pagopa.rtp.sender.domain.gdp.GdpMessage.Status;
 import it.gov.pagopa.rtp.sender.service.registryfile.RegistryDataService;
-import it.gov.pagopa.rtp.sender.service.rtp.SendRTPService;
+import it.gov.pagopa.rtp.sender.service.rtp.SendRTPServiceImpl;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.lang.NonNull;
@@ -31,7 +31,7 @@ import reactor.core.publisher.Mono;
 public class OperationProcessorFactory {
 
   private final GdpMapper gdpMapper;
-  private final SendRTPService sendRTPService;
+  private final SendRTPServiceImpl sendRTPService;
   private final GdpEventHubProperties gdpEventHubProperties;
   private final RegistryDataService registryDataService;
 
@@ -47,7 +47,7 @@ public class OperationProcessorFactory {
    */
   public OperationProcessorFactory(
           @NonNull final GdpMapper gdpMapper,
-          @NonNull final SendRTPService sendRTPService,
+          @NonNull final SendRTPServiceImpl sendRTPService,
           @NonNull final GdpEventHubProperties gdpEventHubProperties,
           @NonNull final RegistryDataService registryDataService) {
 

--- a/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/business/UpdateOperationProcessor.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/business/UpdateOperationProcessor.java
@@ -9,7 +9,7 @@ import it.gov.pagopa.rtp.sender.domain.registryfile.ServiceProvider;
 import it.gov.pagopa.rtp.sender.domain.rtp.Rtp;
 import it.gov.pagopa.rtp.sender.domain.rtp.RtpStatus;
 import it.gov.pagopa.rtp.sender.service.registryfile.RegistryDataService;
-import it.gov.pagopa.rtp.sender.service.rtp.SendRTPService;
+import it.gov.pagopa.rtp.sender.service.rtp.SendRTPServiceImpl;
 import java.util.List;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
@@ -35,7 +35,7 @@ import reactor.core.publisher.Mono;
 public abstract class UpdateOperationProcessor implements OperationProcessor {
 
   protected final RegistryDataService registryDataService;
-  protected final SendRTPService sendRTPService;
+  protected final SendRTPServiceImpl sendRTPService;
   protected final GdpEventHubProperties gdpEventHubProperties;
   protected final List<RtpStatus> acceptedStatuses;
   protected final Status statusToHandle;
@@ -53,7 +53,7 @@ public abstract class UpdateOperationProcessor implements OperationProcessor {
    */
   protected UpdateOperationProcessor(
       @NonNull final RegistryDataService registryDataService,
-      @NonNull final SendRTPService sendRTPService,
+      @NonNull final SendRTPServiceImpl sendRTPService,
       @NonNull final GdpEventHubProperties gdpEventHubProperties,
       @NonNull final List<RtpStatus> acceptedStatuses,
       @NonNull final Status statusToHandle) {

--- a/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/business/UpdatePaidOperationProcessor.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/business/UpdatePaidOperationProcessor.java
@@ -82,7 +82,15 @@ public class UpdatePaidOperationProcessor extends UpdateOperationProcessor {
    */
   @NonNull
   private Mono<Rtp> handleSamePsp(@NonNull final Rtp rtp) {
-    return Mono.error(new UnsupportedOperationException("Not supported yet"));
+    return Mono.just(rtp)
+        .doFirst(() ->
+            log.info("Handling paid RTP with same psp scenario. Id: {}, PSP BIC: {}", rtp.resourceID().getId(), rtp.serviceProviderDebtor()))
+
+        .flatMap(this.sendRTPService::updateRtpPaid)
+
+        .doOnSuccess(rtpUpdated ->
+            log.info("Successfully updated paid RTP with same psp scenario. Id: {}, PSP BIC: {}", rtp.resourceID().getId(), rtp.serviceProviderDebtor()))
+        .doOnError(throwable -> log.error("Error updating paid RTP. Id: {}, PSP BIC: {}", rtp.resourceID().getId(), rtp.serviceProviderDebtor(), throwable));
   }
 
 

--- a/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/business/UpdatePaidOperationProcessor.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/business/UpdatePaidOperationProcessor.java
@@ -6,7 +6,7 @@ import it.gov.pagopa.rtp.sender.domain.gdp.GdpMessage.Status;
 import it.gov.pagopa.rtp.sender.domain.rtp.Rtp;
 import it.gov.pagopa.rtp.sender.domain.rtp.RtpStatus;
 import it.gov.pagopa.rtp.sender.service.registryfile.RegistryDataService;
-import it.gov.pagopa.rtp.sender.service.rtp.SendRTPService;
+import it.gov.pagopa.rtp.sender.service.rtp.SendRTPServiceImpl;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.lang.NonNull;
@@ -42,7 +42,7 @@ public class UpdatePaidOperationProcessor extends UpdateOperationProcessor {
    */
   public UpdatePaidOperationProcessor(
       @NonNull final RegistryDataService registryDataService,
-      @NonNull final SendRTPService sendRTPService,
+      @NonNull final SendRTPServiceImpl sendRTPService,
       @NonNull final GdpEventHubProperties gdpEventHubProperties) {
 
     super(

--- a/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/business/UpdatePaidOperationProcessor.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/business/UpdatePaidOperationProcessor.java
@@ -74,11 +74,14 @@ public class UpdatePaidOperationProcessor extends UpdateOperationProcessor {
 
 
   /**
-   * Handles updates for RTPs where the PSP tax code matches the debtor service provider.
+   * Handles the update of an RTP (Request to Pay) when the payer's PSP (Payment Service Provider) tax code
+   * matches the debtor service provider, indicating the same PSP is involved on both sides.
+   * <p>
+   * This method delegates the update to the {@link SendRTPServiceImpl}.
+   * </p>
    *
-   * @param rtp the RTP with matching PSP and debtor service provider; must not be {@code null}
-   * @return a {@link Mono} signaling the result of the handling
-   * @throws UnsupportedOperationException always, as this method is not yet implemented
+   * @param rtp the RTP to be updated; must not be {@code null}
+   * @return a {@link Mono} emitting the updated {@link Rtp} on success, or an error if the update fails
    */
   @NonNull
   private Mono<Rtp> handleSamePsp(@NonNull final Rtp rtp) {

--- a/src/main/java/it/gov/pagopa/rtp/sender/service/rtp/SendRTPServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/service/rtp/SendRTPServiceImpl.java
@@ -50,7 +50,7 @@ import reactor.core.publisher.Mono;
     SepaRequestToPayCancellationRequestResourceDto.class,
     SynchronousRequestToPayCancellationResponseDto.class
 })
-public class SendRTPServiceImpl implements SendRTPService {
+public class SendRTPServiceImpl implements SendRTPService, UpdateRtpService {
 
   private final SepaRequestToPayMapper sepaRequestToPayMapper;
   private final ReadApi activationApi;
@@ -155,6 +155,14 @@ public class SendRTPServiceImpl implements SendRTPService {
             .doOnNext(rtp -> log.info("Successfully found RTP with id: {}", rtp.resourceID().getId()))
             .switchIfEmpty(Mono.error(new RtpNotFoundException(operationId, eventDispatcher)));
   }
+
+
+  @Override
+  @NonNull
+  public Mono<Rtp> updateRtpPaid(@NonNull final Rtp rtp) {
+    return Mono.empty();
+  }
+
 
   private Throwable mapActivationResponseToException(WebClientResponseException exception) {
     return switch (exception.getStatusCode()) {

--- a/src/main/java/it/gov/pagopa/rtp/sender/service/rtp/SendRTPServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/service/rtp/SendRTPServiceImpl.java
@@ -160,7 +160,12 @@ public class SendRTPServiceImpl implements SendRTPService, UpdateRtpService {
   @Override
   @NonNull
   public Mono<Rtp> updateRtpPaid(@NonNull final Rtp rtp) {
-    return Mono.empty();
+    return Mono.just(rtp)
+        .doFirst(() -> log.info("Updating paid RTP with id: {}", rtp.resourceID().getId()))
+        .flatMap(this.rtpStatusUpdater::triggerPayRtp)
+
+        .doOnSuccess(rtpUpdated -> log.info("Successfully updated paid RTP with id: {}", rtp.resourceID().getId()))
+        .doOnError(error -> log.error("Error updating paid RTP: {}", error.getMessage()));
   }
 
 

--- a/src/main/java/it/gov/pagopa/rtp/sender/service/rtp/UpdateRtpService.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/service/rtp/UpdateRtpService.java
@@ -1,0 +1,10 @@
+package it.gov.pagopa.rtp.sender.service.rtp;
+
+import it.gov.pagopa.rtp.sender.domain.rtp.Rtp;
+import reactor.core.publisher.Mono;
+
+public interface UpdateRtpService {
+
+  Mono<Rtp> updateRtpPaid(Rtp rtp);
+
+}

--- a/src/test/java/it/gov/pagopa/rtp/sender/domain/gdp/business/OperationProcessorFactoryTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/sender/domain/gdp/business/OperationProcessorFactoryTest.java
@@ -9,7 +9,7 @@ import it.gov.pagopa.rtp.sender.domain.gdp.GdpMessage;
 import it.gov.pagopa.rtp.sender.domain.gdp.GdpMessage.Operation;
 import it.gov.pagopa.rtp.sender.domain.gdp.GdpMessage.Status;
 import it.gov.pagopa.rtp.sender.service.registryfile.RegistryDataService;
-import it.gov.pagopa.rtp.sender.service.rtp.SendRTPService;
+import it.gov.pagopa.rtp.sender.service.rtp.SendRTPServiceImpl;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,7 +28,7 @@ class OperationProcessorFactoryTest {
   private GdpMapper gdpMapper;
 
   @Mock
-  private SendRTPService sendRTPService;
+  private SendRTPServiceImpl sendRTPService;
 
   @Mock
   private GdpEventHubProperties gdpEventHubProperties;

--- a/src/test/java/it/gov/pagopa/rtp/sender/domain/gdp/business/UpdatePaidOperationProcessorTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/sender/domain/gdp/business/UpdatePaidOperationProcessorTest.java
@@ -12,7 +12,7 @@ import it.gov.pagopa.rtp.sender.domain.registryfile.ServiceProvider;
 import it.gov.pagopa.rtp.sender.domain.rtp.Rtp;
 import it.gov.pagopa.rtp.sender.domain.rtp.RtpStatus;
 import it.gov.pagopa.rtp.sender.service.registryfile.RegistryDataService;
-import it.gov.pagopa.rtp.sender.service.rtp.SendRTPService;
+import it.gov.pagopa.rtp.sender.service.rtp.SendRTPServiceImpl;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,7 +34,7 @@ class UpdatePaidOperationProcessorTest {
   private RegistryDataService registryDataService;
 
   @Mock
-  private SendRTPService sendRTPService;
+  private SendRTPServiceImpl sendRTPService;
 
   @Mock
   private GdpEventHubProperties gdpEventHubProperties;

--- a/src/test/java/it/gov/pagopa/rtp/sender/domain/gdp/business/UpdatePaidOperationProcessorTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/sender/domain/gdp/business/UpdatePaidOperationProcessorTest.java
@@ -9,6 +9,7 @@ import it.gov.pagopa.rtp.sender.domain.errors.ServiceProviderNotFoundException;
 import it.gov.pagopa.rtp.sender.domain.gdp.GdpMessage;
 import it.gov.pagopa.rtp.sender.domain.gdp.GdpMessage.Status;
 import it.gov.pagopa.rtp.sender.domain.registryfile.ServiceProvider;
+import it.gov.pagopa.rtp.sender.domain.rtp.ResourceID;
 import it.gov.pagopa.rtp.sender.domain.rtp.Rtp;
 import it.gov.pagopa.rtp.sender.domain.rtp.RtpStatus;
 import it.gov.pagopa.rtp.sender.service.registryfile.RegistryDataService;
@@ -49,9 +50,10 @@ class UpdatePaidOperationProcessorTest {
 
   @ParameterizedTest
   @MethodSource("provideValidRtpStatuses")
-  void givenValidRtpStatusAndMatchingPsp_whenProcessOperation_thenThrowsUnsupportedOperationException(RtpStatus rtpStatus) {
+  void givenValidRtpStatusAndMatchingPsp_whenProcessOperation_thenUpdateRtp(RtpStatus rtpStatus) {
     final var inputOperationId = 1L;
     final var inputPspTaxCode = "psp-code";
+    final var resourceID = ResourceID.createNew();
 
     final var message = GdpMessage.builder()
         .id(inputOperationId)
@@ -60,7 +62,14 @@ class UpdatePaidOperationProcessorTest {
         .build();
 
     final var rtp = Rtp.builder()
+        .resourceID(resourceID)
         .status(rtpStatus)
+        .serviceProviderDebtor("sp-id")
+        .build();
+
+    final var updatedRtp = Rtp.builder()
+        .resourceID(resourceID)
+        .status(RtpStatus.PAID)
         .serviceProviderDebtor("sp-id")
         .build();
 
@@ -70,11 +79,52 @@ class UpdatePaidOperationProcessorTest {
         .thenReturn(Mono.just(rtp));
     when(registryDataService.getServiceProvidersByPspTaxCode())
         .thenReturn(Mono.just(Map.of(inputPspTaxCode, serviceProvider)));
+    when(sendRTPService.updateRtpPaid(rtp))
+        .thenReturn(Mono.just(updatedRtp));
 
     final var result = processor.processOperation(message);
 
     StepVerifier.create(result)
-        .expectError(UnsupportedOperationException.class)
+        .expectNext(updatedRtp)
+        .verifyComplete();
+  }
+
+
+  @ParameterizedTest
+  @MethodSource("provideValidRtpStatuses")
+  void givenValidRtpStatusAndMatchingPspFails_whenProcessOperation_thenThrowsIllegalStateException(RtpStatus rtpStatus) {
+    final var inputOperationId = 1L;
+    final var inputPspTaxCode = "psp-code";
+    final var resourceID = ResourceID.createNew();
+
+    final var message = GdpMessage.builder()
+        .id(inputOperationId)
+        .pspTaxCode(inputPspTaxCode)
+        .status(Status.PAID)
+        .build();
+
+    final var rtp = Rtp.builder()
+        .resourceID(resourceID)
+        .status(rtpStatus)
+        .serviceProviderDebtor("sp-id")
+        .build();
+
+    final var expectedException = new IllegalStateException("error");
+
+    final var serviceProvider = new ServiceProvider("sp-id", "name", "tsp-id", inputPspTaxCode);
+
+    when(sendRTPService.findRtpByCompositeKey(inputOperationId, "dispatcher"))
+        .thenReturn(Mono.just(rtp));
+    when(registryDataService.getServiceProvidersByPspTaxCode())
+        .thenReturn(Mono.just(Map.of(inputPspTaxCode, serviceProvider)));
+    when(sendRTPService.updateRtpPaid(rtp))
+        .thenReturn(Mono.error(expectedException));
+
+    final var result = processor.processOperation(message);
+
+    StepVerifier.create(result)
+        .expectErrorMatches(ex -> ex instanceof IllegalStateException
+            && ex.getMessage().equals(expectedException.getMessage()))
         .verify();
   }
 

--- a/src/test/java/it/gov/pagopa/rtp/sender/service/rtp/SendRTPServiceTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/sender/service/rtp/SendRTPServiceTest.java
@@ -412,12 +412,51 @@ class SendRTPServiceTest {
             .verify();
   }
 
+  @Test
+  void givenValidRtp_whenUpdateRtpPaid_thenUpdateSuccessfully() {
+    final var rtp = mock(Rtp.class);
+    final var resourceID = new ResourceID(UUID.randomUUID());
+    final var updatedRtp = mock(Rtp.class);
+
+    when(rtp.resourceID())
+        .thenReturn(resourceID);
+
+    when(rtpStatusUpdater.triggerPayRtp(rtp))
+        .thenReturn(Mono.just(updatedRtp));
+
+    StepVerifier.create(sendRTPService.updateRtpPaid(rtp))
+        .expectNext(updatedRtp)
+        .verifyComplete();
+
+    verify(rtpStatusUpdater).triggerPayRtp(rtp);
+  }
+
+  @Test
+  void givenTriggerPayFails_whenUpdateRtpPaid_thenThrowsIllegalStateException() {
+    final var rtp = mock(Rtp.class);
+    final var resourceID = new ResourceID(UUID.randomUUID());
+    final var exception = new IllegalStateException("Update failed");
+
+    when(rtp.resourceID())
+        .thenReturn(resourceID);
+
+    when(rtpStatusUpdater.triggerPayRtp(rtp))
+        .thenReturn(Mono.error(exception));
+
+    StepVerifier.create(sendRTPService.updateRtpPaid(rtp))
+        .expectErrorMatches(throwable -> throwable instanceof IllegalStateException &&
+            throwable.getMessage().equals("Update failed"))
+        .verify();
+
+    verify(rtpStatusUpdater).triggerPayRtp(rtp);
+  }
+
+
   private Rtp mockRtpWithStatus(RtpStatus status, UUID id) {
     return Rtp.builder()
             .resourceID(new ResourceID(id))
             .status(status)
             .build();
   }
-
 
 }


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR's goal is to implement the effective handling _UPDATE_ scenario with `GdpMessage.Status.PAID` status when the message and the _RTP_ have the same _PSP tax code_: it basically just triggers the state machine with the `RtpEvent.PAY_RTP` by means of `RtpStatusUpdater` facade.

#### List of Changes
<!--- Describe your changes in detail -->
- Created `UpdateRtpService` interface;
- had `SendRTPServiceImpl` implement the above interface with paid status update logic;
- provided meaningful implementation of method `UpdatePaidOperationProcessor::handleSamePsp`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is the final implementation of the first of the two scenarios pertaining to _UPDATE_ operation with _PAID_ status.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [X] Unit
  - [ ] Integration (Narrow)
- Post-Deploy Test
  - [ ] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] PATCH - Bug fix (backwards compatible bug fixes)
- [X] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
