### PR TITLE
chore: [SRTP-741] expose SendRTPService::cancelRtp without database query

### DIFF
--- a/src/main/java/it/gov/pagopa/rtp/sender/controller/rtp/SendAPIControllerImpl.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/controller/rtp/SendAPIControllerImpl.java
@@ -69,7 +69,7 @@ public class SendAPIControllerImpl implements RtpsApi {
 
     return Mono.just(rtpId)
         .map(ResourceID::new)
-        .flatMap(sendRTPService::cancelRtp)
+        .flatMap(sendRTPService::cancelRtpById)
         .<ResponseEntity<Void>>map(rtp -> ResponseEntity
             .noContent().build())
         .onErrorReturn(RtpNotFoundException.class,

--- a/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/business/DeleteOperationProcessor.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/business/DeleteOperationProcessor.java
@@ -48,7 +48,7 @@ public class DeleteOperationProcessor implements OperationProcessor {
      * If the message status is {@code VALID}, it attempts to:
      * <ul>
      *   <li>Retrieve the corresponding {@link Rtp} using the operationId and eventDispatcher</li>
-     *   <li>Cancel the RTP by calling {@link SendRTPService#cancelRtp}</li>
+     *   <li>Cancel the RTP by calling {@link SendRTPService#cancelRtpById}</li>
      * </ul>
      * If the message is not valid, it logs a warning and skips processing.
      *
@@ -70,7 +70,7 @@ public class DeleteOperationProcessor implements OperationProcessor {
                 .doOnNext(message -> log.debug("GDP message with id {} is VALID. Retrieving RTP...", message.id()))
                 .flatMap(message -> sendRTPService.findRtpByCompositeKey(message.id(), this.gdpEventHubProperties.eventDispatcher()))
                 .doOnNext(rtp -> log.info("Cancelling RTP with resourceID {}", rtp.resourceID()))
-                .flatMap(rtp -> sendRTPService.cancelRtp(rtp.resourceID()))
+                .flatMap(rtp -> sendRTPService.cancelRtpById(rtp.resourceID()))
                 .doOnSuccess(rtp -> log.info("Successfully processed GDP message with id: {}", gdpMessage.id()))
                 .doOnError(error -> log.error("Failed to process GDP message with id {}: {}", gdpMessage.id(), error.getMessage(), error));
     }

--- a/src/main/java/it/gov/pagopa/rtp/sender/service/rtp/SendRTPService.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/service/rtp/SendRTPService.java
@@ -11,7 +11,7 @@ public interface SendRTPService {
 
     Mono<Rtp> send(Rtp rtp);
 
-    Mono<Rtp> cancelRtp(ResourceID rtpId);
+    Mono<Rtp> cancelRtpById(ResourceID rtpId);
 
     Mono<Rtp> findRtp(UUID rtpId);
 

--- a/src/main/java/it/gov/pagopa/rtp/sender/service/rtp/SendRTPService.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/service/rtp/SendRTPService.java
@@ -11,6 +11,8 @@ public interface SendRTPService {
 
     Mono<Rtp> send(Rtp rtp);
 
+    Mono<Rtp> cancelRtp(Rtp rtp);
+
     Mono<Rtp> cancelRtpById(ResourceID rtpId);
 
     Mono<Rtp> findRtp(UUID rtpId);

--- a/src/main/java/it/gov/pagopa/rtp/sender/service/rtp/SendRTPServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/service/rtp/SendRTPServiceImpl.java
@@ -110,7 +110,7 @@ public class SendRTPServiceImpl implements SendRTPService, UpdateRtpService {
 
   @NonNull
   @Override
-  public Mono<Rtp> cancelRtp(@NonNull final ResourceID rtpId) {
+  public Mono<Rtp> cancelRtpById(@NonNull final ResourceID rtpId) {
     return this.rtpRepository
         .findById(rtpId)
         .doFirst(() -> log.info("Retrieving RTP with id {}", rtpId.getId()))

--- a/src/main/java/it/gov/pagopa/rtp/sender/service/rtp/SendRTPServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/service/rtp/SendRTPServiceImpl.java
@@ -119,12 +119,14 @@ public class SendRTPServiceImpl implements SendRTPService, UpdateRtpService {
             rtp -> log.info("RTP retrieved with id {} and status {}", rtp.resourceID().getId(),
                 rtp.status()))
         .doOnError(error -> log.error("Error retrieving RTP: {}", error.getMessage(), error))
-        .flatMap(this::doCancelRtp);
+        .flatMap(this::cancelRtp);
 
   }
 
 
-  private Mono<Rtp> doCancelRtp(@NonNull final Rtp rtpToCancel) {
+  @NonNull
+  @Override
+  public Mono<Rtp> cancelRtp(@NonNull final Rtp rtpToCancel) {
     final var rtpToCancelMono = Mono.just(rtpToCancel)
         .flatMap(rtp -> this.rtpStatusUpdater.canCancel(rtp)
         .filter(Boolean::booleanValue)
@@ -204,7 +206,7 @@ public class SendRTPServiceImpl implements SendRTPService, UpdateRtpService {
   public Mono<Rtp> updateRtpCancelPaid(@NonNull final Rtp rtp) {
     return Mono.just(rtp)
         .doFirst(() -> log.info("Cancelling RTP with id: {}", rtp.resourceID().getId()))
-        .flatMap(this::doCancelRtp)
+        .flatMap(this::cancelRtp)
         .doOnNext(cancelledRtp -> log.info("Successfully cancelled RTP with id: {}", rtp.resourceID().getId()))
 
         .doOnNext(cancelledRtp -> log.info("Updating cancelled paid RTP with id: {}", rtp.resourceID().getId()))

--- a/src/test/java/it/gov/pagopa/rtp/sender/controller/rtp/SendAPIControllerImplTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/sender/controller/rtp/SendAPIControllerImplTest.java
@@ -298,7 +298,7 @@ class SendAPIControllerImplTest {
     final var cancelledRtp =
         Rtp.builder().resourceID(new ResourceID(rtpId)).status(RtpStatus.CANCELLED).build();
 
-    when(sendRTPService.cancelRtp(any(ResourceID.class))).thenReturn(Mono.just(cancelledRtp));
+    when(sendRTPService.cancelRtpById(any(ResourceID.class))).thenReturn(Mono.just(cancelledRtp));
 
     webTestClient
         .post()
@@ -315,7 +315,7 @@ class SendAPIControllerImplTest {
   void givenNonExistingRtpId_whenCancelRtp_thenReturnNotFound() {
     final var rtpId = UUID.randomUUID();
 
-    when(sendRTPService.cancelRtp(any(ResourceID.class)))
+    when(sendRTPService.cancelRtpById(any(ResourceID.class)))
         .thenReturn(Mono.error(new RtpNotFoundException(rtpId)));
 
     webTestClient
@@ -333,7 +333,7 @@ class SendAPIControllerImplTest {
   void givenUnexpectedError_whenCancelRtp_thenReturnInternalServerError() {
     final var rtpId = UUID.randomUUID();
 
-    when(sendRTPService.cancelRtp(any(ResourceID.class)))
+    when(sendRTPService.cancelRtpById(any(ResourceID.class)))
         .thenReturn(Mono.error(new RuntimeException("Unexpected error")));
 
     webTestClient
@@ -351,7 +351,7 @@ class SendAPIControllerImplTest {
   void givenInvalidRtpStatus_whenCancelRtp_thenReturnUnprocessableEntity() {
     final var rtpId = UUID.randomUUID();
 
-    when(sendRTPService.cancelRtp(any(ResourceID.class)))
+    when(sendRTPService.cancelRtpById(any(ResourceID.class)))
         .thenReturn(Mono.error(new IllegalStateException()));
 
     webTestClient

--- a/src/test/java/it/gov/pagopa/rtp/sender/domain/gdp/business/DeleteOperationProcessorTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/sender/domain/gdp/business/DeleteOperationProcessorTest.java
@@ -50,14 +50,14 @@ class DeleteOperationProcessorTest {
 
         when(gdpEventHubProperties.eventDispatcher()).thenReturn(eventDispatcher);
         when(sendRTPService.findRtpByCompositeKey(operationId, eventDispatcher)).thenReturn(Mono.just(rtp));
-        when(sendRTPService.cancelRtp(rtp.resourceID())).thenReturn(Mono.just(rtp));
+        when(sendRTPService.cancelRtpById(rtp.resourceID())).thenReturn(Mono.just(rtp));
 
         StepVerifier.create(processor.processOperation(gdpMessage))
                 .expectNext(rtp)
                 .verifyComplete();
 
         verify(sendRTPService).findRtpByCompositeKey(operationId, eventDispatcher);
-        verify(sendRTPService).cancelRtp(rtp.resourceID());
+        verify(sendRTPService).cancelRtpById(rtp.resourceID());
     }
 
     @Test
@@ -91,6 +91,6 @@ class DeleteOperationProcessorTest {
                 .verify();
 
         verify(sendRTPService).findRtpByCompositeKey(operationId, eventDispatcher);
-        verify(sendRTPService, never()).cancelRtp(any());
+        verify(sendRTPService, never()).cancelRtpById(any());
     }
 }

--- a/src/test/java/it/gov/pagopa/rtp/sender/service/rtp/SendRTPServiceTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/sender/service/rtp/SendRTPServiceTest.java
@@ -206,7 +206,7 @@ class SendRTPServiceTest {
 
 
   @Test
-  void givenExistingCreatedRtp_whenCancelRtp_thenShouldSetCancelledStatusAndSave() {
+  void givenExistingCreatedRtp_whenCancelRtp_ById_thenShouldSetCancelledStatusAndSave() {
     final var rtpId = ResourceID.createNew();
     final var createdRtp = mockRtp(RtpStatus.CREATED, rtpId, LocalDateTime.now());
     final var cancelRtp = mockRtp(RtpStatus.CANCELLED, rtpId, LocalDateTime.now());
@@ -216,7 +216,7 @@ class SendRTPServiceTest {
     when(sendRtpProcessor.sendRtpCancellationToServiceProviderDebtor(createdRtp))
         .thenReturn(Mono.just(cancelRtp));
 
-    final var result = sendRTPService.cancelRtp(rtpId);
+    final var result = sendRTPService.cancelRtpById(rtpId);
 
     StepVerifier.create(result)
         .assertNext(rtp -> {
@@ -231,12 +231,12 @@ class SendRTPServiceTest {
   }
 
   @Test
-  void givenNonExistingRtp_whenCancelRtp_thenShouldThrowRtpNotFoundException() {
+  void givenNonExistingRtp_whenCancelRtp_thenShouldThrowRtpByIdNotFoundException() {
     final var rtpId = ResourceID.createNew();
 
     when(rtpRepository.findById(rtpId)).thenReturn(Mono.empty());
 
-    final var result = sendRTPService.cancelRtp(rtpId);
+    final var result = sendRTPService.cancelRtpById(rtpId);
 
     StepVerifier.create(result)
         .expectError(RtpNotFoundException.class)
@@ -248,7 +248,7 @@ class SendRTPServiceTest {
   }
 
   @Test
-  void givenRtpInCreatedStatus_whenCancelRtp_thenShouldSucceed() {
+  void givenRtpInCreatedStatus_whenCancelRtp_ById_thenShouldSucceed() {
     UUID rtpId = UUID.randomUUID();
     ResourceID resourceID = new ResourceID(rtpId);
     Rtp mockRtp = mockRtpWithStatus(RtpStatus.CREATED, rtpId);
@@ -257,7 +257,7 @@ class SendRTPServiceTest {
     when(rtpStatusUpdater.canCancel(mockRtp)).thenReturn(Mono.just(true));
     when(sendRtpProcessor.sendRtpCancellationToServiceProviderDebtor(mockRtp)).thenReturn(Mono.just(mockRtp));
 
-    StepVerifier.create(sendRTPService.cancelRtp(resourceID))
+    StepVerifier.create(sendRTPService.cancelRtpById(resourceID))
             .expectNext(mockRtp)
             .verifyComplete();
 
@@ -267,7 +267,7 @@ class SendRTPServiceTest {
   }
 
   @Test
-  void givenRtpInNotAllowedStatus_whenCancelRtp_thenThrowsIllegalStateException() {
+  void givenRtpInNotAllowedStatus_whenCancelRtp_ById_thenThrowsIllegalStateException() {
     UUID rtpId = UUID.randomUUID();
     ResourceID resourceID = new ResourceID(rtpId);
     Rtp mockRtp = mockRtpWithStatus(RtpStatus.PAID, rtpId);
@@ -275,7 +275,7 @@ class SendRTPServiceTest {
     when(rtpRepository.findById(resourceID)).thenReturn(Mono.just(mockRtp));
     when(rtpStatusUpdater.canCancel(mockRtp)).thenReturn(Mono.just(false));
 
-    StepVerifier.create(sendRTPService.cancelRtp(resourceID))
+    StepVerifier.create(sendRTPService.cancelRtpById(resourceID))
             .expectErrorMatches(err ->
                     err instanceof IllegalStateException &&
                             err.getMessage().contains(rtpId.toString()))
@@ -288,13 +288,13 @@ class SendRTPServiceTest {
   }
 
   @Test
-  void givenNonExistentRtp_whenCancelRtp_thenThrowsRtpNotFoundException() {
+  void givenNonExistentRtp_whenCancelRtp_thenThrowsRtpByIdNotFoundException() {
     UUID rtpId = UUID.randomUUID();
     ResourceID resourceID = new ResourceID(rtpId);
 
     when(rtpRepository.findById(resourceID)).thenReturn(Mono.empty());
 
-    StepVerifier.create(sendRTPService.cancelRtp(resourceID))
+    StepVerifier.create(sendRTPService.cancelRtpById(resourceID))
             .expectError(RtpNotFoundException.class)
             .verify();
 
@@ -497,7 +497,7 @@ class SendRTPServiceTest {
   }
 
   @Test
-  void givenCancelRtpFails_whenUpdateRtpCancelPaid_thenThrowsIllegalStateException() {
+  void givenCancelRtpFails_whenUpdateRtpCancelPaid_thenThrowsIllegalStateExceptionById() {
     final var resourceID = ResourceID.createNew();
     final var rtp = mockRtp(RtpStatus.CREATED, resourceID, LocalDateTime.now());
 


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR's intent is to refactor `SendRTPService` interface to expose two methods to cancel an _RTP_:
- `SendRTPService::cancelRtp` which takes the `Rtp` to cancel as input;
- `SendRTPService::cancelRtpById` which takes the `ResourceId` of the associated `Rtp` and then fetches it form database.

#### List of Changes
<!--- Describe your changes in detail -->
- Renamed existing `SendRTPService::cancelRtp` to `SendRTPService::cancelRtpById`;
- exposed `SendRTPServiceImpl::doCancelRtp` with name `cancelRtp`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is of convenience for business logic related to _UPDATE_ scenarios which require cancelling an `Rtp` that has already been fetched from database, therefore removing the need of a new query.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [X] Unit
  - [ ] Integration (Narrow)
- Post-Deploy Test
  - [ ] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] PATCH - Bug fix (backwards compatible bug fixes)
- [X] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
