### PR TITLE
feat: [SRTP-648] implement business logic for update draft scenario

### DIFF
--- a/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/business/OperationProcessorFactory.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/business/OperationProcessorFactory.java
@@ -100,7 +100,6 @@ public class OperationProcessorFactory {
 
   /**
    * Creates a processor instance for {@link Operation#UPDATE} based on the {@link Status}.
-   * <p>Currently, only {@link Status#PAID} is supported.</p>
    *
    * @param gdpMessage the GDP message to evaluate; must not be {@code null}
    * @return the appropriate {@link OperationProcessor} for the UPDATE operation
@@ -121,6 +120,9 @@ public class OperationProcessorFactory {
       case INVALID, EXPIRED->
           new UpdateInvalidOrExpiredOperationProcessor(
               this.registryDataService, this.sendRTPService, this.gdpEventHubProperties);
+      
+      case DRAFT -> new UpdateDraftOperationProcessor(
+          this.registryDataService, this.sendRTPService, this.gdpEventHubProperties);
 
       default ->
           throw new UnsupportedOperationException(

--- a/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/business/UpdateDraftOperationProcessor.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/business/UpdateDraftOperationProcessor.java
@@ -7,6 +7,7 @@ import it.gov.pagopa.rtp.sender.domain.rtp.Rtp;
 import it.gov.pagopa.rtp.sender.domain.rtp.RtpStatus;
 import it.gov.pagopa.rtp.sender.service.registryfile.RegistryDataService;
 import it.gov.pagopa.rtp.sender.service.rtp.SendRTPServiceImpl;
+import java.util.Collections;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.lang.NonNull;
@@ -40,7 +41,8 @@ public class UpdateDraftOperationProcessor extends UpdateOperationProcessor {
       @NonNull final GdpEventHubProperties gdpEventHubProperties) {
 
     super(
-        registryDataService, sendRTPService, gdpEventHubProperties, ACCEPTED_STATUSES, Status.DRAFT);
+        registryDataService, sendRTPService, gdpEventHubProperties,
+        ACCEPTED_STATUSES, Collections.singletonList(Status.DRAFT));
   }
 
 

--- a/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/business/UpdateDraftOperationProcessor.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/business/UpdateDraftOperationProcessor.java
@@ -13,6 +13,9 @@ import org.springframework.lang.NonNull;
 import reactor.core.publisher.Mono;
 
 
+/**
+ * Operation processor responsible for handling GDP messages that update RTPs in {@link Status#DRAFT} state.
+ */
 @Slf4j
 public class UpdateDraftOperationProcessor extends UpdateOperationProcessor {
 
@@ -21,6 +24,16 @@ public class UpdateDraftOperationProcessor extends UpdateOperationProcessor {
   );
 
 
+  /**
+   * Constructs a new {@code UpdateOperationProcessor} with required dependencies.
+   *
+   * @param registryDataService   the service for accessing registry data; must not be {@code null}
+   * @param sendRTPService        the service for sending or retrieving RTPs; must not be
+   *                              {@code null}
+   * @param gdpEventHubProperties the configuration properties for the Event Hub; must not be
+   *                              {@code null}
+   * @throws NullPointerException if any argument is {@code null}
+   */
   protected UpdateDraftOperationProcessor(
       @NonNull final RegistryDataService registryDataService,
       @NonNull final SendRTPServiceImpl sendRTPService,
@@ -31,6 +44,13 @@ public class UpdateDraftOperationProcessor extends UpdateOperationProcessor {
   }
 
 
+  /**
+   * Cancels the RTP if the current state and message are compatible with {@link Status#DRAFT}.
+   *
+   * @param rtp        the RTP to cancel; must not be {@code null}
+   * @param gdpMessage the GDP message triggering the update; must not be {@code null}
+   * @return a {@link Mono} emitting the cancelled {@link Rtp}, or an error if the operation fails
+   */
   @Override
   @NonNull
   protected Mono<Rtp> updateRtp(

--- a/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/business/UpdateDraftOperationProcessor.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/business/UpdateDraftOperationProcessor.java
@@ -1,0 +1,47 @@
+package it.gov.pagopa.rtp.sender.domain.gdp.business;
+
+import it.gov.pagopa.rtp.sender.configuration.GdpEventHubProperties;
+import it.gov.pagopa.rtp.sender.domain.gdp.GdpMessage;
+import it.gov.pagopa.rtp.sender.domain.gdp.GdpMessage.Status;
+import it.gov.pagopa.rtp.sender.domain.rtp.Rtp;
+import it.gov.pagopa.rtp.sender.domain.rtp.RtpStatus;
+import it.gov.pagopa.rtp.sender.service.registryfile.RegistryDataService;
+import it.gov.pagopa.rtp.sender.service.rtp.SendRTPServiceImpl;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
+import reactor.core.publisher.Mono;
+
+
+@Slf4j
+public class UpdateDraftOperationProcessor extends UpdateOperationProcessor {
+
+  private static final List<RtpStatus> ACCEPTED_STATUSES = List.of(
+      RtpStatus.CREATED, RtpStatus.SENT, RtpStatus.ACCEPTED, RtpStatus.USER_ACCEPTED
+  );
+
+
+  protected UpdateDraftOperationProcessor(
+      @NonNull final RegistryDataService registryDataService,
+      @NonNull final SendRTPServiceImpl sendRTPService,
+      @NonNull final GdpEventHubProperties gdpEventHubProperties) {
+
+    super(
+        registryDataService, sendRTPService, gdpEventHubProperties, ACCEPTED_STATUSES, Status.DRAFT);
+  }
+
+
+  @Override
+  @NonNull
+  protected Mono<Rtp> updateRtp(
+      @NonNull final Rtp rtp, @NonNull final GdpMessage gdpMessage) {
+
+    return Mono.just(rtp)
+        .doFirst(() -> log.info("Cancelling draft RTP with id: {}", rtp.resourceID().getId()))
+        .flatMap(this.sendRTPService::cancelRtp)
+
+        .doOnSuccess(cancelledRtp -> log.info("Successfully cancelled draft RTP with id: {}", rtp.resourceID().getId()))
+        .doOnError(ex -> log.error("Error cancelling draft RTP: {}", ex.getMessage(), ex));
+
+  }
+}

--- a/src/test/java/it/gov/pagopa/rtp/sender/domain/gdp/business/OperationProcessorFactoryTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/sender/domain/gdp/business/OperationProcessorFactoryTest.java
@@ -109,7 +109,8 @@ class OperationProcessorFactoryTest {
 
         Arguments.of(Operation.UPDATE, Status.PAID, UpdatePaidOperationProcessor.class),
         Arguments.of(Operation.UPDATE, Status.INVALID, UpdateInvalidOrExpiredOperationProcessor.class),
-        Arguments.of(Operation.UPDATE, Status.EXPIRED, UpdateInvalidOrExpiredOperationProcessor.class)
+        Arguments.of(Operation.UPDATE, Status.EXPIRED, UpdateInvalidOrExpiredOperationProcessor.class),
+        Arguments.of(Operation.UPDATE, Status.DRAFT, UpdateDraftOperationProcessor.class)
     );
   }
 
@@ -118,7 +119,8 @@ class OperationProcessorFactoryTest {
         Arguments.of(Operation.UPDATE, Status.VALID),
         Arguments.of(Operation.UPDATE, Status.PARTIALLY_PAID),
         Arguments.of(Operation.UPDATE, Status.PUBLISHED),
-        Arguments.of(Operation.UPDATE, Status.DRAFT)
+        Arguments.of(Operation.UPDATE, Status.DRAFT),
+        Arguments.of(Operation.UPDATE, Status.EXPIRED)
     );
   }
 

--- a/src/test/java/it/gov/pagopa/rtp/sender/domain/gdp/business/OperationProcessorFactoryTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/sender/domain/gdp/business/OperationProcessorFactoryTest.java
@@ -118,9 +118,7 @@ class OperationProcessorFactoryTest {
     return Stream.of(
         Arguments.of(Operation.UPDATE, Status.VALID),
         Arguments.of(Operation.UPDATE, Status.PARTIALLY_PAID),
-        Arguments.of(Operation.UPDATE, Status.PUBLISHED),
-        Arguments.of(Operation.UPDATE, Status.DRAFT),
-        Arguments.of(Operation.UPDATE, Status.EXPIRED)
+        Arguments.of(Operation.UPDATE, Status.PUBLISHED)
     );
   }
 

--- a/src/test/java/it/gov/pagopa/rtp/sender/domain/gdp/business/UpdateDraftOperationProcessorTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/sender/domain/gdp/business/UpdateDraftOperationProcessorTest.java
@@ -1,0 +1,213 @@
+package it.gov.pagopa.rtp.sender.domain.gdp.business;
+
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import it.gov.pagopa.rtp.sender.configuration.GdpEventHubProperties;
+import it.gov.pagopa.rtp.sender.domain.errors.RtpNotFoundException;
+import it.gov.pagopa.rtp.sender.domain.gdp.GdpMessage;
+import it.gov.pagopa.rtp.sender.domain.gdp.GdpMessage.Status;
+import it.gov.pagopa.rtp.sender.domain.rtp.ResourceID;
+import it.gov.pagopa.rtp.sender.domain.rtp.Rtp;
+import it.gov.pagopa.rtp.sender.domain.rtp.RtpStatus;
+import it.gov.pagopa.rtp.sender.service.registryfile.RegistryDataService;
+import it.gov.pagopa.rtp.sender.service.rtp.SendRTPServiceImpl;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateDraftOperationProcessorTest {
+
+  private static final Status VALID_STATUS = Status.DRAFT;
+
+
+  @Mock
+  private RegistryDataService registryDataService;
+
+  @Mock
+  private SendRTPServiceImpl sendRTPService;
+
+  @Mock
+  private GdpEventHubProperties gdpEventHubProperties;
+
+  private UpdateDraftOperationProcessor processor;
+
+  @BeforeEach
+  void setUp() {
+    lenient().when(gdpEventHubProperties.eventDispatcher()).thenReturn("dispatcher");
+    processor = new UpdateDraftOperationProcessor(registryDataService, sendRTPService, gdpEventHubProperties);
+  }
+
+
+  @ParameterizedTest
+  @MethodSource("provideValidRtpStatuses")
+  void givenValidRtpStatus_whenProcessOperation_thenCancelRtp(RtpStatus rtpStatus) {
+    final var inputOperationId = 1L;
+    final var inputPspTaxCode = "psp-code";
+    final var resourceID = ResourceID.createNew();
+
+    final var message = GdpMessage.builder()
+        .id(inputOperationId)
+        .psp_tax_code(inputPspTaxCode)
+        .status(VALID_STATUS)
+        .build();
+
+    final var rtp = Rtp.builder()
+        .resourceID(resourceID)
+        .status(rtpStatus)
+        .serviceProviderDebtor("sp-id")
+        .build();
+
+    final var cancelledRtp = Rtp.builder()
+        .resourceID(resourceID)
+        .status(RtpStatus.CANCELLED)
+        .serviceProviderDebtor("sp-id")
+        .build();
+
+    when(sendRTPService.findRtpByCompositeKey(inputOperationId, "dispatcher"))
+        .thenReturn(Mono.just(rtp));
+    when(sendRTPService.cancelRtp(rtp))
+        .thenReturn(Mono.just(cancelledRtp));
+
+    final var result = processor.processOperation(message);
+
+    StepVerifier.create(result)
+        .expectNext(cancelledRtp)
+        .verifyComplete();
+  }
+
+
+  @ParameterizedTest
+  @MethodSource("provideValidRtpStatuses")
+  void givenVErrorUponCancellingRtp_whenProcessOperation_thenPropagateError(RtpStatus rtpStatus) {
+    final var inputOperationId = 1L;
+    final var inputPspTaxCode = "psp-code";
+    final var resourceID = ResourceID.createNew();
+
+    final var message = GdpMessage.builder()
+        .id(inputOperationId)
+        .psp_tax_code(inputPspTaxCode)
+        .status(VALID_STATUS)
+        .build();
+
+    final var rtp = Rtp.builder()
+        .resourceID(resourceID)
+        .status(rtpStatus)
+        .serviceProviderDebtor("sp-id")
+        .build();
+
+    final var exception = new RuntimeException("cancel failed");
+
+    when(sendRTPService.findRtpByCompositeKey(inputOperationId, "dispatcher"))
+        .thenReturn(Mono.just(rtp));
+    when(sendRTPService.cancelRtp(rtp))
+        .thenReturn(Mono.error(exception));
+
+    final var result = processor.processOperation(message);
+
+    StepVerifier.create(result)
+        .expectErrorMatches(ex ->
+            ex instanceof RuntimeException
+                && ex.getMessage().equals("cancel failed"))
+        .verify();
+  }
+
+
+  private static Stream<Arguments> provideValidRtpStatuses() {
+    return Stream.of(
+        //Arguments.of(RtpStatus.CREATED),
+        //Arguments.of(RtpStatus.SENT),
+        //Arguments.of(RtpStatus.ACCEPTED),
+        Arguments.of(RtpStatus.USER_ACCEPTED)
+    );
+  }
+
+
+  @ParameterizedTest
+  @MethodSource("provideInvalidRtpStatuses")
+  void givenInvalidRtpStatus_whenProcessOperation_thenThrowsIllegalArgumentException(RtpStatus invalidRtpStatus) {
+    final var message = GdpMessage.builder()
+        .id(1L)
+        .psp_tax_code("psp-code")
+        .status(VALID_STATUS)
+        .build();
+
+    final var rtp = Rtp.builder()
+        .status(invalidRtpStatus)
+        .build();
+
+    when(sendRTPService.findRtpByCompositeKey(1L, "dispatcher"))
+        .thenReturn(Mono.just(rtp));
+
+    final var result = processor.processOperation(message);
+
+    StepVerifier.create(result)
+        .expectError(IllegalArgumentException.class)
+        .verify();
+  }
+
+
+  private static Stream<Arguments> provideInvalidRtpStatuses() {
+    return Stream.of(
+        Arguments.of(RtpStatus.CANCELLED),
+        Arguments.of(RtpStatus.REJECTED),
+        Arguments.of(RtpStatus.USER_REJECTED),
+        Arguments.of(RtpStatus.PAID),
+        Arguments.of(RtpStatus.ERROR_SEND),
+        Arguments.of(RtpStatus.CANCELLED_PAID),
+        Arguments.of(RtpStatus.CANCELLED_ACCR),
+        Arguments.of(RtpStatus.CANCELLED_REJECTED),
+        Arguments.of(RtpStatus.ERROR_CANCEL)
+    );
+  }
+
+
+  @Test
+  void givenRtpNotFound_whenProcessOperation_thenThrowsRtpNotFoundException() {
+    final var inputOperationId = 1L;
+    final var inputEventDispatcher = "dispatcher";
+
+    final var message = GdpMessage.builder()
+        .id(inputOperationId)
+        .psp_tax_code("psp-code")
+        .status(VALID_STATUS)
+        .build();
+
+    when(sendRTPService.findRtpByCompositeKey(inputOperationId, inputEventDispatcher))
+        .thenReturn(Mono.error(new RtpNotFoundException(inputOperationId, inputEventDispatcher)));
+
+    final var result = processor.processOperation(message);
+
+    StepVerifier.create(result)
+        .expectError(RtpNotFoundException.class)
+        .verify();
+  }
+
+
+  @ParameterizedTest
+  @EnumSource(value = Status.class, mode = EnumSource.Mode.EXCLUDE, names = "DRAFT")
+  void givenNonDraftStatus_whenProcessOperation_thenThrowsIllegalArgumentException(Status nonPaidStatus) {
+    final var message = GdpMessage.builder()
+        .id(1L)
+        .psp_tax_code("psp-code")
+        .status(nonPaidStatus)
+        .build();
+
+    final var result = processor.processOperation(message);
+
+    StepVerifier.create(result)
+        .expectError(IllegalArgumentException.class)
+        .verify();
+  }
+
+}


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR aims to implement _UPDATE DRAFT_ scenario: it does so by creating a new strategy class, namely `UpdateDraftOperationProcessor` that handles this scenario, which entails sending a _Request for Cancellation (RfC)_ to the _Debtor Service Provider_ in the _RTP_.

#### List of Changes
<!--- Describe your changes in detail -->
- Created `UpdateDraftOperationProcessor` containing all business logic;
- hooked that class in the `OperationProcessorFactory`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is needed to handle messages form _GPD_ with `Operation.UPDATE` and `Status.DRAFT`.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [X] Unit
  - [X] Integration (Narrow)
- Post-Deploy Test
  - [X] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] PATCH - Bug fix (backwards compatible bug fixes)
- [X] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
