### PR TITLE
fix: [SRTP-747] accept null status in the pagopa payload from the eventHub

### DIFF
--- a/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/GdpMessage.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/GdpMessage.java
@@ -38,7 +38,8 @@ public record GdpMessage(
     EXPIRED,
     INVALID,
     DRAFT,
-    PUBLISHED
+    PUBLISHED,
+    NULL
   }
 
 }

--- a/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/GdpMessage.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/GdpMessage.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.Builder;
 import org.springframework.validation.annotation.Validated;
+import java.util.Optional;
 
 
 @Validated
@@ -24,6 +25,11 @@ public record GdpMessage(
     String psp_code,
     String psp_tax_code
 ) {
+
+  public GdpMessage{
+    status = Optional.ofNullable(status)
+            .orElse(Status.NULL);
+  }
 
   public enum Operation {
     CREATE,

--- a/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/GdpMessageProcessor.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/GdpMessageProcessor.java
@@ -69,7 +69,7 @@ public class GdpMessageProcessor implements MessageProcessor<GdpMessage, Mono<Rt
                 .getProcessor(payload)
                 .flatMap(operationProcessor -> operationProcessor.processOperation(payload)))
         .contextWrite(ctx -> ctx
-                .put("foreignStatus", message.status() != null ? message.status() : GdpMessage.Status.NULL)
+                .put("foreignStatus", message.status())
                 .put("eventDispatcher",eventDispatcher));
   }
 }

--- a/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/GdpMessageProcessor.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/GdpMessageProcessor.java
@@ -61,7 +61,6 @@ public class GdpMessageProcessor implements MessageProcessor<GdpMessage, Mono<Rt
   @NonNull
   public Mono<Rtp> processMessage(@NonNull final GdpMessage message) {
     Objects.requireNonNull(message, "GdpMessage cannot be null");
-    final var foreignStatus = Objects.requireNonNull(message.status(),"foreignStatus is required");
     final var eventDispatcher = Objects.requireNonNull(this.gdpEventHubProperties.eventDispatcher(),"eventDispatcher is required");
 
     return Mono.fromSupplier(() -> message)
@@ -70,7 +69,7 @@ public class GdpMessageProcessor implements MessageProcessor<GdpMessage, Mono<Rt
                 .getProcessor(payload)
                 .flatMap(operationProcessor -> operationProcessor.processOperation(payload)))
         .contextWrite(ctx -> ctx
-                .put("foreignStatus", foreignStatus)
+                .put("foreignStatus", message.status())
                 .put("eventDispatcher",eventDispatcher));
   }
 }

--- a/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/GdpMessageProcessor.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/GdpMessageProcessor.java
@@ -61,6 +61,7 @@ public class GdpMessageProcessor implements MessageProcessor<GdpMessage, Mono<Rt
   @NonNull
   public Mono<Rtp> processMessage(@NonNull final GdpMessage message) {
     Objects.requireNonNull(message, "GdpMessage cannot be null");
+    final var foreignStatus = Objects.requireNonNull(message.status(), "GdpMessage status cannot be null");
     final var eventDispatcher = Objects.requireNonNull(this.gdpEventHubProperties.eventDispatcher(),"eventDispatcher is required");
 
     return Mono.fromSupplier(() -> message)
@@ -69,7 +70,7 @@ public class GdpMessageProcessor implements MessageProcessor<GdpMessage, Mono<Rt
                 .getProcessor(payload)
                 .flatMap(operationProcessor -> operationProcessor.processOperation(payload)))
         .contextWrite(ctx -> ctx
-                .put("foreignStatus", message.status())
+                .put("foreignStatus",foreignStatus)
                 .put("eventDispatcher",eventDispatcher));
   }
 }

--- a/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/GdpMessageProcessor.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/GdpMessageProcessor.java
@@ -69,7 +69,7 @@ public class GdpMessageProcessor implements MessageProcessor<GdpMessage, Mono<Rt
                 .getProcessor(payload)
                 .flatMap(operationProcessor -> operationProcessor.processOperation(payload)))
         .contextWrite(ctx -> ctx
-                .put("foreignStatus", message.status())
+                .put("foreignStatus", message.status() != null ? message.status() : GdpMessage.Status.NULL)
                 .put("eventDispatcher",eventDispatcher));
   }
 }

--- a/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/business/DeleteOperationProcessor.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/business/DeleteOperationProcessor.java
@@ -63,11 +63,6 @@ public class DeleteOperationProcessor implements OperationProcessor {
 
         return Mono.just(gdpMessage)
                 .doFirst(() -> log.info("Processing GDP message with id {}", gdpMessage.id()))
-                .filter(message -> message.status() == GdpMessage.Status.VALID)
-                .switchIfEmpty(Mono.fromRunnable(() ->
-                        log.warn("Skipping GDP message with id {} due to non-VALID status: {}", gdpMessage.id(), gdpMessage.status())
-                ))
-                .doOnNext(message -> log.debug("GDP message with id {} is VALID. Retrieving RTP...", message.id()))
                 .flatMap(message -> sendRTPService.findRtpByCompositeKey(message.id(), this.gdpEventHubProperties.eventDispatcher()))
                 .doOnNext(rtp -> log.info("Cancelling RTP with resourceID {}", rtp.resourceID()))
                 .flatMap(rtp -> sendRTPService.cancelRtpById(rtp.resourceID()))

--- a/src/test/java/it/gov/pagopa/rtp/sender/domain/gdp/GdpMessageProcessorTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/sender/domain/gdp/GdpMessageProcessorTest.java
@@ -137,4 +137,28 @@ class GdpMessageProcessorTest {
 
     assertEquals("eventDispatcher is required", exception.getMessage());
   }
+
+  @Test
+  void givenMessageWithNullStatus_whenProcessed_thenContextUsesStatusNullEnum() {
+    final var message = GdpMessage.builder()
+            .operation(GdpMessage.Operation.CREATE)
+            .status(null)
+            .build();
+
+    final var rtp = Rtp.builder().build();
+
+    when(gdpEventHubProperties.eventDispatcher()).thenReturn("test-dispatcher");
+    when(operationProcessorFactory.getProcessor(message)).thenReturn(Mono.just(operationProcessor));
+    when(operationProcessor.processOperation(message))
+            .thenReturn(Mono.deferContextual(ctx -> Mono.just(rtp)));
+
+    StepVerifier.create(gdpMessageProcessor.processMessage(message))
+            .expectAccessibleContext()
+            .contains("foreignStatus", GdpMessage.Status.NULL)
+            .contains("eventDispatcher", "test-dispatcher")
+            .then()
+            .expectNext(rtp)
+            .verifyComplete();
+  }
+
 }

--- a/src/test/java/it/gov/pagopa/rtp/sender/domain/gdp/GdpMessageProcessorTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/sender/domain/gdp/GdpMessageProcessorTest.java
@@ -118,19 +118,6 @@ class GdpMessageProcessorTest {
   }
 
   @Test
-  void givenMessageWithoutStatus_whenProcessed_thenThrowsNullPointerException() {
-    final var message =
-        GdpMessage.builder().operation(GdpMessage.Operation.CREATE).status(null).build();
-
-    final var exception = assertThrows(
-            NullPointerException.class,
-            () -> gdpMessageProcessor.processMessage(message)
-    );
-
-    assertEquals("foreignStatus is required", exception.getMessage());
-  }
-
-  @Test
   void givenNullEventDispatcher_whenProcessed_thenThrowsNullPointerException() {
     final var message =
         GdpMessage.builder()

--- a/src/test/java/it/gov/pagopa/rtp/sender/domain/gdp/business/DeleteOperationProcessorTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/sender/domain/gdp/business/DeleteOperationProcessorTest.java
@@ -35,12 +35,12 @@ class DeleteOperationProcessorTest {
     }
 
     @Test
-    void givenValidGdpMessage_whenProcessOperation_thenRtpIsCancelled() {
+    void givenGdpMessage_whenProcessOperation_thenRtpIsCancelled() {
         final var operationId = 123L;
         final var eventDispatcher = "test-dispatcher";
         final var gdpMessage = GdpMessage.builder()
                 .id(operationId)
-                .status(GdpMessage.Status.VALID)
+                .status(null)
                 .build();
 
         final var rtp = Rtp.builder()
@@ -61,25 +61,12 @@ class DeleteOperationProcessorTest {
     }
 
     @Test
-    void givenNonValidGdpMessage_whenProcessOperation_thenDoNothing() {
-        final var gdpMessage = GdpMessage.builder()
-                .id(123L)
-                .status(GdpMessage.Status.INVALID)
-                .build();
-
-        StepVerifier.create(processor.processOperation(gdpMessage))
-                .verifyComplete();
-
-        verifyNoInteractions(sendRTPService);
-    }
-
-    @Test
     void givenErrorDuringRtpLookup_whenProcessOperation_thenPropagateError() {
         final var operationId = 123L;
         final var eventDispatcher = "test-dispatcher";
         final var gdpMessage = GdpMessage.builder()
                 .id(operationId)
-                .status(GdpMessage.Status.VALID)
+                .status(null)
                 .build();
 
         when(gdpEventHubProperties.eventDispatcher()).thenReturn(eventDispatcher);


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR addresses a failure scenario where incoming messages from the PagoPA queue often contain null values for several fields, including the status field. According to the updated documentation, this is expected and compliant behavior. Therefore, we have removed the mandatory requireNonNull check on message.status() to allow the system to handle such messages gracefully.

#### List of Changes
<!--- Describe your changes in detail -->

- Removed Objects.requireNonNull(message.status(), "foreignStatus is required") in GdpMessageProcessor.
- Replaced the now-removed foreignStatus variable with a direct usage of message.status() where necessary.
- Deleted a block in DeleteOperationProcessor that filtered out messages with status != VALID, as this is no longer a mandatory constraint.
- Add new status added `NULL` status to enum `GdpMessage.Status`.
- Add the default value `GdpMessage.Status.NULL` in the `GdpMessageProcessor.processMessage` method in case of null status

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The motivation behind this change is to align with the documentation stating that incoming messages may legitimately contain null values for several fields, including status. Previously, the application would reject such messages, which led to undesired interruptions in processing.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [x] Unit
  - [x] Integration (Narrow)
- Post-Deploy Test
  - [x] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
