### PR TITLE
fix: [SRTP-809] rename Status PARTIALLY_VALID into PARTIALLY_PAID

### DIFF
--- a/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/GdpMessage.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/domain/gdp/GdpMessage.java
@@ -39,7 +39,7 @@ public record GdpMessage(
 
   public enum Status {
     VALID,
-    PARTIALLY_VALID,
+    PARTIALLY_PAID,
     PAID,
     EXPIRED,
     INVALID,

--- a/src/test/java/it/gov/pagopa/rtp/sender/domain/gdp/business/OperationProcessorFactoryTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/sender/domain/gdp/business/OperationProcessorFactoryTest.java
@@ -93,7 +93,7 @@ class OperationProcessorFactoryTest {
     return Stream.of(
         Arguments.of(Operation.CREATE, Status.VALID, CreateOperationProcessor.class),
         Arguments.of(Operation.CREATE, Status.INVALID, CreateOperationProcessor.class),
-        Arguments.of(Operation.CREATE, Status.PARTIALLY_VALID, CreateOperationProcessor.class),
+        Arguments.of(Operation.CREATE, Status.PARTIALLY_PAID, CreateOperationProcessor.class),
         Arguments.of(Operation.CREATE, Status.PAID, CreateOperationProcessor.class),
         Arguments.of(Operation.CREATE, Status.PUBLISHED, CreateOperationProcessor.class),
         Arguments.of(Operation.CREATE, Status.EXPIRED, CreateOperationProcessor.class),
@@ -101,7 +101,7 @@ class OperationProcessorFactoryTest {
 
         Arguments.of(Operation.DELETE, Status.VALID, DeleteOperationProcessor.class),
         Arguments.of(Operation.DELETE, Status.INVALID, DeleteOperationProcessor.class),
-        Arguments.of(Operation.DELETE, Status.PARTIALLY_VALID, DeleteOperationProcessor.class),
+        Arguments.of(Operation.DELETE, Status.PARTIALLY_PAID, DeleteOperationProcessor.class),
         Arguments.of(Operation.DELETE, Status.PAID, DeleteOperationProcessor.class),
         Arguments.of(Operation.DELETE, Status.PUBLISHED, DeleteOperationProcessor.class),
         Arguments.of(Operation.DELETE, Status.EXPIRED, DeleteOperationProcessor.class),
@@ -116,7 +116,7 @@ class OperationProcessorFactoryTest {
   private static Stream<Arguments> provideUnsupportedOperationsAndStatuses() {
     return Stream.of(
         Arguments.of(Operation.UPDATE, Status.VALID),
-        Arguments.of(Operation.UPDATE, Status.PARTIALLY_VALID),
+        Arguments.of(Operation.UPDATE, Status.PARTIALLY_PAID),
         Arguments.of(Operation.UPDATE, Status.PUBLISHED),
         Arguments.of(Operation.UPDATE, Status.DRAFT)
     );


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR fixes a typo in `GdpMessage.Status`, where the value `PARTIALLY_VALID` needs to be renamed into `PARTIALLY_PAID`.

#### List of Changes
<!--- Describe your changes in detail -->
- Renamed `GdpMessage.Status.PARTIALLY_VALID` needs to be renamed into `GdpMessage.Status.PARTIALLY_PAID`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is required to allow correct processing of incoming messages.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [X] Unit
  - [ ] Integration (Narrow)
- Post-Deploy Test
  - [ ] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
