### PR TITLE
fix: [SRTP-612] change http status code to 404 when payer not activated

### DIFF
--- a/src/main/java/it/gov/pagopa/rtp/sender/controller/rtp/RtpExceptionHandler.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/controller/rtp/RtpExceptionHandler.java
@@ -170,7 +170,6 @@ public class RtpExceptionHandler {
             .code(SendErrorCode.PAYER_NOT_ACTIVATED.getCode())
             .description(SendErrorCode.PAYER_NOT_ACTIVATED.getMessage());
 
-    return ResponseEntity.unprocessableEntity()
-        .body(error);
+    return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
   }
 }

--- a/src/main/java/it/gov/pagopa/rtp/sender/controller/rtp/RtpExceptionHandler.java
+++ b/src/main/java/it/gov/pagopa/rtp/sender/controller/rtp/RtpExceptionHandler.java
@@ -157,7 +157,7 @@ public class RtpExceptionHandler {
    * Handles {@link PayerNotActivatedException} by returning a standardized error response.
    * <p>
    * This method is triggered when a request fails because the payer is not activated.
-   * It returns an HTTP status {@code 422 Unprocessable Entity} along
+   * It returns an HTTP status {@code 404 Not Found} along
    * with {@link SendErrorCode#PAYER_NOT_ACTIVATED} as error code.
    * </p>
    *

--- a/src/test/java/it/gov/pagopa/rtp/sender/controller/rtp/RtpExceptionHandlerTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/sender/controller/rtp/RtpExceptionHandlerTest.java
@@ -132,11 +132,11 @@ class RtpExceptionHandlerTest {
     }
 
     @Test
-    void givenHandlerInvoked_whenPayerNotActivated_thenReturnsUnprocessableEntityWithProperError() {
+    void givenHandlerInvoked_whenPayerNotActivated_thenReturnsNotFoundWithProperError() {
         final var response = rtpExceptionHandler.handlePayerNotActivated();
 
         assertNotNull(response, "Response should not be null");
-        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, response.getStatusCode(), "Status should be 422 Unprocessable Entity");
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode(), "Status should be 404 Not Found");
 
         final var body = response.getBody();
         assertNotNull(body, "Response body should not be null");

--- a/src/test/java/it/gov/pagopa/rtp/sender/controller/rtp/SendAPIControllerImplTest.java
+++ b/src/test/java/it/gov/pagopa/rtp/sender/controller/rtp/SendAPIControllerImplTest.java
@@ -170,7 +170,7 @@ class SendAPIControllerImplTest {
 
   @Test
   @RtpSenderWriter
-  void givenUserNotActivatedWhenSendRTPThenReturnUnprocessableEntity() {
+  void givenUserNotActivatedWhenSendRTPThenReturnNotFound() {
 
     when(rtpDtoMapper.toRtpWithServiceProviderCreditor(any(CreateRtpDto.class), anyString()))
         .thenReturn(expectedRtp);
@@ -182,7 +182,7 @@ class SendAPIControllerImplTest {
         .bodyValue(generateSendRequest())
         .exchange()
         .expectStatus()
-        .isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+        .isEqualTo(HttpStatus.NOT_FOUND);
 
     verify(sendRTPService, times(1)).send(any());
     verify(rtpDtoMapper, times(1)).toRtpWithServiceProviderCreditor(any(), (any()));


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR aims to change the _HTTP status code_ returned upon handling `PayerNotActivatedException` from `422 UNPROCESSABLE ENTITY` to `404 NOT FOUND`.

#### List of Changes
<!--- Describe your changes in detail -->
- Returned `404 NOT FOUND` instead of `422 UNPROCESSABLE ENTITY` in `RtpExceptionHandler`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This has been done to better represent the semantic of the error, also favoring better distinction from other errors with same status code.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [X] Unit
  - [X] Integration (Narrow)
- Post-Deploy Test
  - [X] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
